### PR TITLE
refactor: set test

### DIFF
--- a/diffcse/trainers.py
+++ b/diffcse/trainers.py
@@ -566,6 +566,9 @@ class CLTrainer(Trainer):
             self.control = self.callback_handler.on_epoch_end(self.args, self.state, self.control)
             self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, tr_pos_sim=tr_pos_sim, tr_neg_sim=tr_neg_sim, tr_others=tr_others)
 
+            # validate
+            self.predict()
+
             if self.args.tpu_metrics_debug or self.args.debug:
                 if is_torch_tpu_available():
                     # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)

--- a/transformers-4.2.1/src/transformers/trainer.py
+++ b/transformers-4.2.1/src/transformers/trainer.py
@@ -238,6 +238,7 @@ class Trainer:
         args: TrainingArguments = None,
         data_collator: Optional[DataCollator] = None,
         train_dataset: Optional[Dataset] = None,
+        test_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Dataset] = None,
         tokenizer: Optional["PreTrainedTokenizerBase"] = None,
         model_init: Callable[[], PreTrainedModel] = None,
@@ -278,6 +279,7 @@ class Trainer:
         default_collator = default_data_collator if tokenizer is None else DataCollatorWithPadding(tokenizer)
         self.data_collator = data_collator if data_collator is not None else default_collator
         self.train_dataset = train_dataset
+        self.test_dataset = test_dataset
         self.eval_dataset = eval_dataset
         self.tokenizer = tokenizer
 
@@ -326,12 +328,16 @@ class Trainer:
             raise ValueError("train_dataset does not implement __len__, max_steps has to be specified")
         if eval_dataset is not None and not isinstance(eval_dataset, collections.abc.Sized):
             raise ValueError("eval_dataset must implement __len__")
+        if test_dataset is not None and not isinstance(test_dataset, collections.abc.Sized):
+            raise ValueError("test_dataset must implement __len__")
 
         if is_datasets_available():
             if isinstance(train_dataset, datasets.Dataset):
                 self._remove_unused_columns(self.train_dataset, description="training")
             if isinstance(eval_dataset, datasets.Dataset):
                 self._remove_unused_columns(self.eval_dataset, description="evaluation")
+            if isinstance(test_dataset, datasets.Dataset):
+                self._remove_unused_columns(self.test_dataset, description="test")
 
         # Setup Sharded DDP training
         self.sharded_dpp = False
@@ -1461,7 +1467,7 @@ class Trainer:
         return output.metrics
 
     def predict(
-        self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "eval"
+        self, test_dataset: Dataset, ignore_keys: Optional[List[str]] = None, metric_key_prefix: str = "predict"
     ) -> PredictionOutput:
         """
         Run prediction and returns predictions and potential metrics.
@@ -1503,6 +1509,7 @@ class Trainer:
             test_dataloader, description="Prediction", ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix
         )
         output.metrics.update(speed_metrics(metric_key_prefix, start_time, len(test_dataset)))
+        logger.info(output)
         return output
 
     def prediction_loop(


### PR DESCRIPTION
## 🎉 Why
1. train.py의 main 함수에서 train할 때, CLTrainer를 사용합니다. 
2. CLTrainer는 transformers-4.2.1/src/transformers/trainer.py의 Trainer 클래스를 상속 받습니다.
3. Trainer 클래스에는 predict와 get_test_dataloader 함수가 있지만, 현재는 사용되는 곳이 없고, test_dataset이 초기화되지 않고 있습니다.
4. . test_dataset을 초기화하고, predict를 사용하여 테스트하려고 합니다.


## ✍️ Description
<!-- 본인이 한 작업 설명 -->
<!-- 고민, 개선사항 포함 -->
Trainer에 test_dataset을 초기화할 수 있도록 하고, train.py의 main 함수의 에포크마다 predict 함수를 추가했습니다.